### PR TITLE
go: change the Go version support policy, drop one version

### DIFF
--- a/go.md
+++ b/go.md
@@ -4,17 +4,18 @@
 
 Upon the release of a new version of Go, all repositories are updated
 according to the following conventions:
-* The minimum supported version of Go is set to two versions back from 
-  the previous one. For example, upon the release of Go 1.22, the minimum 
-  version becomes 1.20.
+* The minimum supported version of Go is set to one version back from
+  the current one. For example, upon the release of Go 1.22, the minimum
+  version becomes 1.21 (just like Go itself, release 1.22 makes 1.20
+  unsupported).
 * All dependency packages are updated (sometimes, according to project 
   requirements, some deprecated package methods may be updated as well.)
 * New Go version features are adapted where they make sense or can improve 
   performance.
 * Go versions in GitHub workflows are also updated as follows:
 
-  1. Testing is performed on the last three versions of Go. In the example
-  mentioned above, this would be `[ '1.20', '1.21', '1.22' ]`.
+  1. Testing is performed for the last two versions of Go. In the example
+  mentioned above, this would be `[ '1.21', '1.22' ]`.
   2. For build and cover jobs, the latest version should be used. In the 
   example mentioned above, this would be 1.22. 
   3. If there are new versions of GitHub actions, they can also be updated 


### PR DESCRIPTION
Our policy tried to be a bit more friendly to people, but unfortunately it's somewhat unsynchronized with the rest of the world using Go. This can be a problem for dependency management (including security fixes), newer libraries require newer Go and we're still trying to allow for an older one. Also, an additional version means more test runs and dropping one can save some CI time.

Fixes #30.