### PR TITLE
git: explicitly say that it's OK to fix #28

### DIFF
--- a/git.md
+++ b/git.md
@@ -91,6 +91,7 @@ repository, in this case the subsystem prefix MAY be omitted.
 
 If commit fixes some issue it MUST be mentioned in the message using "fixes
 XXX" (or "closes XXX") notation to automatically close the respective issue.
+These references MAY be placed in the short description (header) if they fit.
 
 Description MUST contain enough data to understand what's going on without
 looking at the linked issues (they're additional data, not the primary thing


### PR DESCRIPTION
Commit messages can be short in which case it's OK to put references into the header, adding some longer body just to put the references doesn't improve things much.