### PR TITLE
.golangci.yml: enable modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,6 +55,9 @@ linters:
     - staticcheck
     - unused
 
+    # code improvements suggestion
+    - modernize
+  
     # extra linters
     # - goconst
     # - err113


### PR DESCRIPTION
Ref. https://ville.dev/blog/posts/go-modernize/. The support of gopls modernize tool is not available (ref.
https://github.com/golangci/golangci-lint/discussions/5466), but this `modernize` linter may be tried instead.

Let's give it a try and remove if it doesn't fit our needs.